### PR TITLE
change duration of log entry based on how common it is

### DIFF
--- a/World/GardenWorld.tscn
+++ b/World/GardenWorld.tscn
@@ -34,7 +34,12 @@ position = Vector2( 5, 5 )
 scale = Vector2( 0.5, 0.5 )
 texture = ExtResource( 2 )
 
+[node name="UpdateRarity" type="Timer" parent="."]
+autostart = true
+
 [node name="LogHandler" type="Node2D" parent="."]
 z_index = 5
 script = ExtResource( 4 )
 LogEntry = ExtResource( 5 )
+
+[connection signal="timeout" from="UpdateRarity" to="LogHandler" method="_on_UpdateRarity_timeout"]

--- a/World/LogEntry/Entry.gd
+++ b/World/LogEntry/Entry.gd
@@ -6,11 +6,12 @@ var target = 0
 
 func _ready():
 	$Label.text = text
+	update_self_worth()
 	pass # Replace with function body.
 
 
 func _process(delta):
-	modulate = lerp(Color.transparent, Color.white, $Timer.time_left / $Timer.wait_time )
+	modulate = lerp(Color.transparent, Color.white, sqrt(min($Timer.time_left, 0.25) / 0.25) )
 	position.y = lerp(position.y, target, delta*10)
 	$Label/Counter.rect_scale = lerp($Label/Counter.rect_scale, Vector2.ONE, delta*15)
 	pass
@@ -21,7 +22,14 @@ func _on_Timer_timeout():
 	pass # Replace with function body.
 
 func respawn():
+	update_self_worth()
 	$Label/Counter.rect_scale = 1.5 * Vector2.ONE
 	count += 1
 	$Timer.start()
 	$Label/Counter.text = "X" + str(count)
+
+func update_self_worth():
+	var unimportance = get_parent().get_entry_count(text)
+	var time_allowed = 5*pow(0.6, sqrt(unimportance)-1)
+	$Timer.wait_time = min(time_allowed, $Timer.wait_time)
+	pass

--- a/World/LogEntry/LogHandler.gd
+++ b/World/LogEntry/LogHandler.gd
@@ -1,6 +1,7 @@
 extends Node2D
 export (PackedScene) var LogEntry
 export var v_offset = 12
+var log_repetition_db = [[],[]]
 
 func _ready():
 	pass # Replace with function body.
@@ -9,6 +10,7 @@ func _process(delta):
 	pass
 
 func add_log(message : String):
+	count_log_entry_in_db(message)
 	for child in get_children():
 		if not child.get("text") == null:
 			if child.text.find(message) != -1:
@@ -38,14 +40,35 @@ func remove_log(node_to_remove):
 func update_log_positions():
 	var max_count = 0
 	if get_child_count() > 0:
-		max_count = get_child(0).count
+		max_count = get_entry_count(get_child(0).text)
 		
 		
 	for i in range(1, get_child_count()):
-		if get_child(i).count > max_count:
-			max_count = get_child(i).count
+		if get_entry_count(get_child(i).text) > max_count:
+			max_count = get_entry_count(get_child(i).text)
 			move_child(get_child(i), i-1)
 	
 	for i in range(get_child_count()):
 		get_child(i).target = i * v_offset
 	pass
+
+func count_log_entry_in_db(log_text):
+	var search_result = log_repetition_db[0].find(log_text)
+	if search_result == -1:
+		log_repetition_db[0].append(log_text)
+		log_repetition_db[1].append(1)
+	else:
+		log_repetition_db[1][search_result] += 1
+
+func get_entry_count(log_text) -> int:
+	var search_result = log_repetition_db[0].find(log_text)
+	if search_result == -1:
+		return 0
+	else:
+		return log_repetition_db[1][search_result]
+
+func _on_UpdateRarity_timeout():
+	for entry_index in log_repetition_db[1].size():
+		log_repetition_db[1][entry_index] = ceil(0.5 * log_repetition_db[1][entry_index])
+	
+#	print(log_repetition_db)


### PR DESCRIPTION
every time an entry is encountered its repeats get a +1, every second the repeats are close to halved. This results in most log entries you dont see often have repeats around 1 most of the time, while the meowing of the cats has a higher value.
Then a number between 0 and 1 is brought to the power of  the sqrt-ed repeats and multiplied by 3-5 ish (lifespan of rare log).
Tweak how the falloff works by changing how often the repeats are halved (timer in main scene), and by changing the numbers in the lifespan calculation (Entry.gd, line 33)